### PR TITLE
Add support for illumos/Solaris ls flags

### DIFF
--- a/zfs_versions.py
+++ b/zfs_versions.py
@@ -13,6 +13,8 @@ from subprocess import check_output, call, check_call, STDOUT
 
 if sys.platform[:5] == 'linux':
     LS = 'ls -ltr --time-style=full-iso'
+elif sys.platform == 'sunos5':
+    LS = '/usr/bin/ls -ltrE'
 else:
     LS = 'ls -Tltr'
 


### PR DESCRIPTION
On illumos and similar systems, the ls command uses different flags to display the full timestamp. This also uses the full path to ls, because there may be other versions of ls ( specifically, ls from GNU coreutils ) in their path. But having GNU ls is not guaranteed.

Tested on OpenIndiana, and Solaris 11.3.
